### PR TITLE
 hotfix - fix service of add admin user

### DIFF
--- a/src/comunidades/comunidades.service.ts
+++ b/src/comunidades/comunidades.service.ts
@@ -121,7 +121,7 @@ export class ComunidadesService {
   async addAdminUser(communityAdminUser: CommunityUserDto) {
     // don't catch and rethrow exception here, as the intention is
     // to let it go back to the gateway
-    await this.getCommunityUser(communityAdminUser);
+    await this.getById(communityAdminUser.communityId);
 
     const relation = new this.userAdminRelationModel(communityAdminUser);
 


### PR DESCRIPTION
O endpoint de add admin user consultava a lista de usuários antes de adicionar e por isso dava erro.

Signed-off-by: Arthur <arthurarp@hotmail.com>